### PR TITLE
Stats recording system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
+/Assets/Stats/
+/Assets/Stats.meta
 /[Uu]ser[Ss]ettings/
 
 # MemoryCaptures can get excessive in size.

--- a/Assets/Prefabs/Animated/players/player1_animated.prefab
+++ b/Assets/Prefabs/Animated/players/player1_animated.prefab
@@ -622,6 +622,7 @@ GameObject:
   - component: {fileID: 9051456166870169758}
   - component: {fileID: 7901286178603807775}
   - component: {fileID: 675003948274067448}
+  - component: {fileID: 459147860987707909}
   m_Layer: 0
   m_Name: player1_animated
   m_TagString: Player
@@ -780,7 +781,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0db359481445997489767d60736902bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _intNames: []
+  _intNames:
+  - playerId
   _floatNames:
   - moveSpeed
   - moveSpeedMultiplierPickup
@@ -791,6 +793,21 @@ MonoBehaviour:
   - holdingWagon
   _vector2Names:
   - feetDirection
+--- !u!114 &459147860987707909
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4891051678069208517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c454899bb45027243b6a50c1c759d6ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _obvc: {fileID: 675003948274067448}
+  _playerIdValueName: playerId
+  _id: 1
 --- !u!1 &5155380218449298551
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Animated/players/player2_animated.prefab
+++ b/Assets/Prefabs/Animated/players/player2_animated.prefab
@@ -694,6 +694,7 @@ GameObject:
   - component: {fileID: 588415828336237354}
   - component: {fileID: 7901286178603807775}
   - component: {fileID: 675003948274067448}
+  - component: {fileID: 4680618843132286972}
   m_Layer: 0
   m_Name: player2_animated
   m_TagString: Player
@@ -852,7 +853,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0db359481445997489767d60736902bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _intNames: []
+  _intNames:
+  - playerId
   _floatNames:
   - moveSpeed
   - moveSpeedMultiplierPickup
@@ -863,6 +865,21 @@ MonoBehaviour:
   - holdingWagon
   _vector2Names:
   - feetDirection
+--- !u!114 &4680618843132286972
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4891051678069208517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c454899bb45027243b6a50c1c759d6ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _obvc: {fileID: 675003948274067448}
+  _playerIdValueName: playerId
+  _id: 2
 --- !u!1 &5500858678457047716
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Animated/players/player3_animated.prefab
+++ b/Assets/Prefabs/Animated/players/player3_animated.prefab
@@ -519,6 +519,7 @@ GameObject:
   - component: {fileID: 7901286178603807775}
   - component: {fileID: 6117595668027425725}
   - component: {fileID: 675003948274067448}
+  - component: {fileID: 296985666896983184}
   m_Layer: 0
   m_Name: player3_animated
   m_TagString: Player
@@ -689,7 +690,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0db359481445997489767d60736902bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _intNames: []
+  _intNames:
+  - playerId
   _floatNames:
   - moveSpeed
   - moveSpeedMultiplierPickup
@@ -700,6 +702,21 @@ MonoBehaviour:
   - holdingWagon
   _vector2Names:
   - feetDirection
+--- !u!114 &296985666896983184
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4891051678069208517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c454899bb45027243b6a50c1c759d6ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _obvc: {fileID: 675003948274067448}
+  _playerIdValueName: playerId
+  _id: 3
 --- !u!1 &5245524240316787047
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Animated/players/player4_animated.prefab
+++ b/Assets/Prefabs/Animated/players/player4_animated.prefab
@@ -478,6 +478,7 @@ GameObject:
   - component: {fileID: 7901286178603807775}
   - component: {fileID: 6117595668027425725}
   - component: {fileID: 675003948274067448}
+  - component: {fileID: 7985784040153593284}
   m_Layer: 0
   m_Name: player4_animated
   m_TagString: Player
@@ -648,7 +649,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0db359481445997489767d60736902bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _intNames: []
+  _intNames:
+  - playerId
   _floatNames:
   - moveSpeed
   - moveSpeedMultiplierPickup
@@ -659,6 +661,21 @@ MonoBehaviour:
   - holdingWagon
   _vector2Names:
   - feetDirection
+--- !u!114 &7985784040153593284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4891051678069208517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c454899bb45027243b6a50c1c759d6ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _obvc: {fileID: 675003948274067448}
+  _playerIdValueName: playerId
+  _id: 4
 --- !u!1 &5268584452483073648
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/interactions.unity
+++ b/Assets/Scenes/interactions.unity
@@ -274,6 +274,68 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: bce72ed8a9185a743a71afdf746c8f57, type: 3}
   m_PrefabInstance: {fileID: 1057471924}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &142702697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 142702700}
+  - component: {fileID: 142702699}
+  - component: {fileID: 142702698}
+  m_Layer: 0
+  m_Name: StatsManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &142702698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 142702697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db359481445997489767d60736902bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _intNames: []
+  _floatNames: []
+  _boolNames: []
+  _vector2Names: []
+--- !u!114 &142702699
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 142702697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11868ac0be4c3ff49a7b27727d5acb1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _obvc: {fileID: 142702698}
+--- !u!4 &142702700
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 142702697}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &189154717
 GameObject:
   m_ObjectHideFlags: 0
@@ -2701,6 +2763,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2020664595}
   - component: {fileID: 2020664594}
+  - component: {fileID: 2020664596}
   m_Layer: 0
   m_Name: PlayerManager
   m_TagString: Untagged
@@ -2726,7 +2789,19 @@ MonoBehaviour:
   m_JoinBehavior: 0
   m_PlayerJoinedEvent:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2020664596}
+        m_TargetAssemblyTypeName: player_prefab_switcher, Assembly-CSharp
+        m_MethodName: NextPrefab
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_PlayerLeftEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -2767,6 +2842,23 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2020664596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2020664593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ee38385329b3d941a96b3db2174fdd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerPrefabs:
+  - {fileID: 4891051678069208517, guid: ba5ae939410802849835cbffc4342cfc, type: 3}
+  - {fileID: 4891051678069208517, guid: a91016fe7d628264389bee3ef1112534, type: 3}
+  - {fileID: 4891051678069208517, guid: 62fa9d9540a9ab1429e2c6f442d7ba96, type: 3}
+  - {fileID: 4891051678069208517, guid: 3c0fd409bd6e3e0469addf120df32271, type: 3}
 --- !u!1001 &2066801926
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3027,3 +3119,4 @@ SceneRoots:
   - {fileID: 8007434151376601802}
   - {fileID: 669519280}
   - {fileID: 1594805063}
+  - {fileID: 142702700}

--- a/Assets/Scripts/interaction_system/interactor.cs
+++ b/Assets/Scripts/interaction_system/interactor.cs
@@ -22,7 +22,7 @@ public abstract class interactor : MonoBehaviour
     /// An observable value collection is attached to the interactor
     /// so that interactables can interact with it.
     /// </summary>
-    [SerializeField]private observable_value_collection _obvc;
+    [SerializeField]protected observable_value_collection _obvc;
     /// <summary>
     /// The interactor can begin and end interactions. All active interactions
     /// are stored in this stack. Pop the top to get the top active interaction.

--- a/Assets/Scripts/interaction_system/player_interactor.cs
+++ b/Assets/Scripts/interaction_system/player_interactor.cs
@@ -10,6 +10,13 @@ public class player_interactor : interactor
     [SerializeField]private float _interactRange;
     [SerializeField]private TextMeshPro _textMeshPro;
 
+    
+    // Stats
+    [SerializeField] private string _playerIdValueName= "playerId";
+    [SerializeField] private string _nrOfInteractionsValueName = "interactions";
+    [SerializeField] private string _nrOfWagonInteractionsValueName = "steerWagonInteractions";
+    [SerializeField] private string _nrOfPackagesPickedUp = "packagesPickedUp";
+
     void OnEnable()
     {
         _playerInput.actions["interact"].started += HandleInteract;
@@ -28,6 +35,16 @@ public class player_interactor : interactor
             if(hit.collider.TryGetComponent<interactable_object>(out var interactable))
             {
                 BeginInteraction(interactable);
+                stats_manager.Instance.IncIntStat("Player" + _obvc.GetObservableInt(_playerIdValueName).Value + " " + _nrOfInteractionsValueName,1);
+                switch(interactable)
+                {
+                    case wagon_front_interactable:
+                    stats_manager.Instance.IncIntStat("Player" + _obvc.GetObservableInt(_playerIdValueName).Value + " " +_nrOfWagonInteractionsValueName,1);
+                    break;
+                    case pickup_interactable:
+                    stats_manager.Instance.IncIntStat("Player" + _obvc.GetObservableInt(_playerIdValueName).Value + " " +_nrOfPackagesPickedUp,1);
+                    break;
+                }
             }
             else
             {

--- a/Assets/Scripts/player_id.cs
+++ b/Assets/Scripts/player_id.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class player_id : MonoBehaviour
+{
+    [SerializeField] private observable_value_collection _obvc;
+    [SerializeField] private string _playerIdValueName = "playerId";
+    [SerializeField] private int _id;
+    void Start()
+    {
+        if(_obvc!=null)
+        {
+            _obvc.InvokeInt(_playerIdValueName,_id);
+        }
+    }
+}

--- a/Assets/Scripts/player_id.cs.meta
+++ b/Assets/Scripts/player_id.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c454899bb45027243b6a50c1c759d6ba

--- a/Assets/Scripts/player_prefab_switcher.cs
+++ b/Assets/Scripts/player_prefab_switcher.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+[RequireComponent(typeof(PlayerInputManager))]
+public class player_prefab_switcher : MonoBehaviour
+{
+    private PlayerInputManager _inputManager;
+    [SerializeField] List<GameObject> _playerPrefabs;
+    int i = 0;
+
+    void Awake()
+    {
+        _inputManager = GetComponent<PlayerInputManager>();
+        if(_inputManager.playerPrefab==null && _playerPrefabs.Count > 0)
+        {
+            _inputManager.playerPrefab = _playerPrefabs[0];
+        }
+        if(_playerPrefabs.Count==0)
+        {
+            Debug.Log("Warning: Player prefab switcher is not initialized with any player prefabs to switch to. Players will join with the same prefab. On gameObject " + gameObject.name + ".");
+        }
+    }
+    public void NextPrefab()
+    {
+        if(_playerPrefabs.Count>0)
+        {
+            i++;
+            if(i== _playerPrefabs.Count)
+            {
+                i = 0;
+            }
+            _inputManager.playerPrefab = _playerPrefabs[i];
+        } else{Debug.Log("Warning: Player prefab switcher could not switch prefab. On gameObject " + gameObject.name + ".");}
+    }
+}

--- a/Assets/Scripts/player_prefab_switcher.cs.meta
+++ b/Assets/Scripts/player_prefab_switcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ee38385329b3d941a96b3db2174fdd5

--- a/Assets/Scripts/singleton_persistent.cs
+++ b/Assets/Scripts/singleton_persistent.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class singleton_persistent<T> : MonoBehaviour where T : Component
+{
+    private static T _instance;
+    public static T Instance
+    {
+        get{
+            if(_instance==null)
+            {
+                GameObject go = new GameObject();
+                go.name = typeof(T).Name;
+                go.hideFlags = HideFlags.HideAndDontSave;
+                DontDestroyOnLoad(go);
+                _instance = go.AddComponent<T>();
+            }
+            return _instance;
+        }
+    }
+    public void Awake()
+    {
+        if(_instance==null)
+        {
+            _instance = this as T;
+            DontDestroyOnLoad(this);
+        } else { Destroy(this); }
+    }
+}

--- a/Assets/Scripts/singleton_persistent.cs.meta
+++ b/Assets/Scripts/singleton_persistent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03849e30b2322cc48970e3c34d92d642

--- a/Assets/Scripts/stats_manager.cs
+++ b/Assets/Scripts/stats_manager.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+public class stats_manager : singleton_persistent<stats_manager>
+{
+    [SerializeField] private observable_value_collection _obvc;
+
+    private stats_manager(){}
+
+    public void IncIntStat(string statName, int i){
+        try{_obvc.InvokeInt(statName,i + _obvc.GetObservableInt(statName).Value);} 
+        catch(Exception){_obvc.AddObservableInt(statName);_obvc.InvokeInt(statName,0);}
+        
+    }
+    public void IncFloatStat(string statName, float f )
+    {
+        try{_obvc.InvokeFloat(statName,f + _obvc.GetObservableFloat(statName).Value);}
+        catch(Exception){_obvc.AddObservableFloat(statName);_obvc.InvokeFloat(statName,1f);}
+    }
+    public void SetBoolStat(string statName, bool b)
+    {
+        try{_obvc.InvokeBool(statName,b);}
+        catch(Exception){_obvc.AddObservableBool(statName);_obvc.InvokeBool(statName,b);}
+    }
+
+    void OnDisable()
+    {
+        GenerateLogFiles();
+    }
+
+    public void GenerateLogFiles()
+    {
+        if(_obvc!=null)
+        {
+            string dataPath = Application.dataPath;
+            if(!Directory.EnumerateFiles(dataPath).Contains<string>("Stats"))
+            {
+                Directory.CreateDirectory(dataPath + "/" + "Stats");
+            }
+            string statsPath = dataPath + "/" + "Stats";
+            string fileName = "playerStats.txt";
+            int cnt = 0;
+            while(Directory.GetFiles(statsPath).Contains<string>(statsPath + "\\" +fileName))
+            {
+                cnt += 1;
+                fileName = "playerStats" + cnt.ToString() + ".txt";
+            }
+            using (StreamWriter sw = File.CreateText(statsPath + "/"+ fileName))
+            {
+                sw.WriteLine("Logged at : " + DateTime.Now.ToString("f"));
+                foreach(observable_value<int> i in _obvc.GetObservableIntArray())
+                {
+                    string valueName = i.Name;
+                    int value = i.Value;
+                    sw.WriteLine(valueName + " : " + value);
+                }
+                foreach(observable_value<float> f in _obvc.GetObservableFloatArray())
+                {
+                    string valueName = f.Name;
+                    float value = f.Value;
+                    sw.WriteLine(valueName + " : " + value);
+                }
+                foreach(observable_value<bool> b in _obvc.GetObservableBoolArray())
+                {
+                    string valueName = b.Name;
+                    bool value = b.Value;
+                    sw.WriteLine(valueName + " : " + value);
+                }
+            } Debug.Log("Created gameplay log file at : " + statsPath + "/" + fileName);
+        } else {Debug.Log("Warning: Observable Value Collection is null on stats manager. Stats were not generated.");}
+    }
+}

--- a/Assets/Scripts/stats_manager.cs.meta
+++ b/Assets/Scripts/stats_manager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11868ac0be4c3ff49a7b27727d5acb1c


### PR DESCRIPTION
Stats system that enables tracking of stats of types: int, float, bool. Stats are saved to .txt files under Assets/Stats. Stat files are included in gitignore so they won't be pushed to github.   

Classes:

**player_prefab_switcher** : Switches the player prefab whenever a player joins so each player gets their own color. This class should've been in it's own branch, my mistake.

**stats_manager**:  Keeps track of stats. Extends singleton__persistent. 
Track a stat of type int, float or bool through:

stats_manager.Instance.IncIntStat(string statname, int incrementAmount);
stats_manager.Instance.IncFloatStat(string statname, float incrementAmount);
stats_manager:Instance.SetBoolStat(string statname, bool value);

There is no need to instantiate stats since the first time you increment or set a stat, it is instantiated.

**singleton_persistent**: Generic singleton implementation that persists between scenes through DoNotDestroyOnLoad.